### PR TITLE
Allow multiple starting values in occu

### DIFF
--- a/R/occu.R
+++ b/R/occu.R
@@ -75,10 +75,12 @@ occu <- function(formula, data, knownOcc = numeric(0),
   # Fit model with C++ and R engines-------------------------------------------
   if(engine %in% c("C", "R")){
     if(missing(starts)) starts <- rep(0, nP)
-    if(length(starts) != nP){
+    if(!is.list(starts)) starts <- list(starts)
+    if(any(sapply(starts, length) != nP)){
       stop(paste("The number of starting values should be", nP))
     }
-    fm <- optim(starts, nll, method = method, hessian = se, ...)
+    fits <- lapply(starts, optim, fn=nll, method=method, hessian=se, ...)
+    fm <- fits[[which.min(sapply(fits, `[[`, "value"))]]
     covMat <- invertHessian(fm, nP, se)
     ests <- fm$par
     tmb_mod <- NULL

--- a/man/occu.Rd
+++ b/man/occu.Rd
@@ -19,7 +19,8 @@
       \code{"logit"} for the standard occupancy model or \code{"cloglog"} 
       for the complimentary log-log link, which relates occupancy
       to site-level abundance. See details.}
-    \item{starts}{Vector of parameter starting values.}
+    \item{starts}{Vector of parameter starting values, or a list of candidate
+      starting value vectors.}
     \item{method}{Optimization method used by \code{\link{optim}}.}
     \item{se}{Logical specifying whether or not to compute standard
       errors.}

--- a/tests/testthat/test_occu.R
+++ b/tests/testthat/test_occu.R
@@ -174,6 +174,18 @@ test_that("occu can fit models with covariates",{
   expect_error(fm <- occu(~ o1 + fake ~ o1, data = umf))
 })
 
+test_that("occu can evaluate multiple starting value candidates",{
+  y <- matrix(rep(0:1,10)[1:10],5,2)
+  siteCovs <- data.frame(x = c(0,2,3,4,1))
+  obsCovs <- data.frame(o1 = 1:10, o2 = exp(-5:4)/10)
+  umf <- unmarkedFrameOccu(y = y, siteCovs = siteCovs, obsCovs = obsCovs)
+  starts <- list(rep(20, 5), rep(0, 5))
+
+  fm <- occu(~ o1 + o2 ~ x, data = umf, starts=starts,
+             se = FALSE, control = list(maxit = 0))
+  expect_equal(coef(fm), rep(0, 5))
+})
+
 test_that("occu handles NAs",{
 
   y <- matrix(rep(0:1,10)[1:10],5,2)


### PR DESCRIPTION
Hi!

I've been working with unmarked recently, using the occu() function for occupancy models, and I noticed that the default initialization can sometimes lead to worse optimization results than alternative starting values. To make it easier to find a better starting point, I extended occu() so that the starts argument can accept either a single numeric vector, as before, or a list of candidate starting values. When a list is supplied, occu() fits the model from each candidate and returns the fit with the lowest negative log-likelihood.

To illustrate why I think this would be useful, I ran a small simulation where the model was fit repeatedly to data generated from known values of psi and p. With only the default initialization, the estimates of the detection parameter p were clearly not centered on the true value, shown by the red line in the figure, and had substantially greater dispersion. In addition, although the default starting point was included in the candidate list (so the multiple-start approach can recover the same solution when the default start is adequate), the multiple-start fit had a strictly lower negative log-likelihood in 462 out of 500 simulations (92.4%). It also had no convergence failures, while the single-start fit failed to converge in 9 out of 500 simulations.

<img width="880" height="679" alt="estimates_distribution" src="https://github.com/user-attachments/assets/0be2f461-7595-4f75-930b-77b826b941de" />

**Simulation code:**

```r
library(ggplot2)

# Demonstration script for the occu() multiple-start PR.

# Run from the package root so pkgload uses the PR version.
pkgload::load_all(".")

set.seed(123)

# Simulation settings
n_replications <- 500
N <- 1000
J <- 5
n_inits <- 10
beta <- -3
alpha <- -2.5
psi <- plogis(beta)
p <- plogis(alpha)

# Include the default start as one candidate, then add random alternatives.
start <- c(0, 0)
inits <- c(
  list(start),
  replicate(n_inits - 1, start + runif(length(start), -5, 5), simplify = FALSE)
)

simulate_data <- function(){
  occupancy <- rbinom(N, 1, psi)
  
  detections <- sapply(occupancy, \(z){
    rbinom(J, 1, p * z)
  })
  
  data.frame(t(detections))
}

simulation <- do.call(rbind, lapply(seq_len(n_replications), function(i) {
  umf <- unmarkedFrameOccu(y = simulate_data())
  
  # Fit once with the default single start, and once with candidate starts.
  occu_single_start <- occu(~1 ~ 1, umf)
  occu_multiple_starts <- occu(~1 ~ 1, umf, starts = inits)
  
  results <- rbind(
    coef(occu_single_start),
    coef(occu_multiple_starts)
  )
  
  data.frame(
    replication = i,
    model = rep(c("single", "multiple"), times = 2),
    coefficient = rep(c("psi", "p"), each = 2),
    estimation = c(results[, "psi(Int)"], results[, "p(Int)"]),
    nll = rep(c(occu_single_start@negLogLike,
                occu_multiple_starts@negLogLike), times = 2),
    convergence = rep(c(occu_single_start@opt$convergence,
                        occu_multiple_starts@opt$convergence), times = 2)
  )
}))

# Parameter estimates; red lines are the data-generating values on link scale.
true_values <- data.frame(
  coefficient = c("psi", "p"),
  true_value = c(beta, alpha)
)

ggplot(simulation, aes(x=model, y=estimation)) +
  geom_boxplot() +
  geom_hline(
    data = true_values,
    aes(yintercept = true_value),
    color = "red",
    linewidth = 0.8
  ) +
  facet_wrap(~coefficient, scales = "free_y")

# Compare fit quality once per replication/model.
fit_summary <- unique(simulation[c("replication", "model", "nll", "convergence")])
fit_wide <- reshape(
  fit_summary,
  idvar = "replication",
  timevar = "model",
  direction = "wide"
)

strictly_better <- fit_wide$nll.multiple < fit_wide$nll.single
likelihood_summary <- data.frame(
  metric = "multiple start has strictly lower nll",
  count = sum(strictly_better),
  total = length(strictly_better),
  proportion = mean(strictly_better)
)

convergence_summary <- aggregate(
  convergence ~ model,
  fit_summary,
  function(x) sum(x != 0)
)
names(convergence_summary)[2] <- "convergence_failures"

likelihood_summary
convergence_summary
```

Thank you very much!